### PR TITLE
Added GreenhopperDomain and associated Entities to support retrieving…

### DIFF
--- a/src/Dapplo.Jira.Tests/GreenhopperTests.cs
+++ b/src/Dapplo.Jira.Tests/GreenhopperTests.cs
@@ -1,0 +1,73 @@
+﻿#region Dapplo 2017 - GNU Lesser General Public License
+
+// Dapplo - building blocks for .NET applications
+// Copyright (C) 2017 Dapplo
+// 
+// For more information see: http://dapplo.net/
+// Dapplo repositories are hosted on GitHub: https://github.com/dapplo
+// 
+// This file is part of Dapplo.Jira
+// 
+// Dapplo.Jira is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Dapplo.Jira is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have a copy of the GNU Lesser General Public License
+// along with Dapplo.Jira. If not, see <http://www.gnu.org/licenses/lgpl.txt>.
+
+#endregion
+
+#region Usings
+
+using System.Linq;
+using System.Threading.Tasks;
+using Dapplo.Jira.Enums;
+using Xunit;
+using Xunit.Abstractions;
+
+#endregion
+namespace Dapplo.Jira.Tests
+{
+    /// <summary>
+    ///     Tests for the Greenhopper domain
+    /// </summary>
+    public class GreenhopperTests : TestBase
+    {
+        public GreenhopperTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+        {
+        }
+
+        [Fact]
+        public async Task TestGetSprintReport()
+        {
+            // Arrange
+            var selectedBoard = "greenshot releases";
+            var selectedSprint = "greenshot 1.2.9 bf1";
+
+            var boards = await Client.Agile.GetBoardsAsync();
+            var scrumboard = boards.First(board => board.Type == BoardTypes.Scrum && board.Name.ToLowerInvariant() == selectedBoard);
+            var sprints = await Client.Agile.GetSprintsAsync(scrumboard.Id);
+            var sprint = sprints.First(s => s.Name.ToLowerInvariant() == selectedSprint);
+
+            // Act
+            var report = await Client.Greenhopper.GetSprintReportAsync(scrumboard.Id, sprint.Id);
+
+            // Assert
+            Assert.NotNull(report);
+            Assert.NotEmpty(report.Contents.CompletedIssues);
+            Assert.Equal(7, report.Contents.CompletedIssues.Count());
+            Assert.NotEmpty(report.Contents.IssuesCompletedInAnotherSprint);
+            Assert.Equal(2, report.Contents.IssuesCompletedInAnotherSprint.Count());
+            Assert.NotEmpty(report.Contents.PuntedIssues);
+            Assert.Equal(3, report.Contents.PuntedIssues.Count());
+            Assert.NotEmpty(report.Contents.IssueKeysAddedDuringSprint);
+            Assert.Equal(2, report.Contents.IssueKeysAddedDuringSprint.Count());
+        }
+    }
+}

--- a/src/Dapplo.Jira/AgileExtensions.cs
+++ b/src/Dapplo.Jira/AgileExtensions.cs
@@ -175,7 +175,6 @@ namespace Dapplo.Jira
             return response.HandleErrors();
         }
 
-
         /// <summary>
         ///     Get all issues for a spring
         ///     See

--- a/src/Dapplo.Jira/Domains/IGreenhopperDomain.cs
+++ b/src/Dapplo.Jira/Domains/IGreenhopperDomain.cs
@@ -1,4 +1,4 @@
-#region Dapplo 2017 - GNU Lesser General Public License
+﻿#region Dapplo 2017 - GNU Lesser General Public License
 
 // Dapplo - building blocks for .NET applications
 // Copyright (C) 2017 Dapplo
@@ -23,33 +23,12 @@
 
 #endregion
 
-using System;
-
 namespace Dapplo.Jira.Domains
 {
     /// <summary>
-    ///     This interface describes the functionality of the IJiraClient which domains can use
+    ///     The marker interface for the greenhopper domain
     /// </summary>
-    public interface IJiraDomain : IJiraClient
+    public interface IGreenhopperDomain : IJiraDomain
     {
-        /// <summary>
-        ///     The rest URI for your JIRA server
-        /// </summary>
-        Uri JiraRestUri { get; }
-
-        /// <summary>
-        ///     The agile rest URI for your JIRA server
-        /// </summary>
-        Uri JiraAgileRestUri { get; }
-
-        /// <summary>
-        ///     The base URI for JIRA auth api
-        /// </summary>
-        Uri JiraAuthUri { get; }
-
-        /// <summary>
-        ///     The greenhopper rest URI for your JIRA server
-        /// </summary>
-        Uri JiraGreenhopperRestUri { get; }
     }
 }

--- a/src/Dapplo.Jira/Entities/EpicField.cs
+++ b/src/Dapplo.Jira/Entities/EpicField.cs
@@ -1,0 +1,88 @@
+﻿#region Dapplo 2017 - GNU Lesser General Public License
+
+// Dapplo - building blocks for .NET applications
+// Copyright (C) 2017 Dapplo
+// 
+// For more information see: http://dapplo.net/
+// Dapplo repositories are hosted on GitHub: https://github.com/dapplo
+// 
+// This file is part of Dapplo.Jira
+// 
+// Dapplo.Jira is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Dapplo.Jira is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have a copy of the GNU Lesser General Public License
+// along with Dapplo.Jira. If not, see <http://www.gnu.org/licenses/lgpl.txt>.
+
+#endregion
+
+#region Usings
+
+using Newtonsoft.Json;
+
+#endregion
+
+namespace Dapplo.Jira.Entities
+{
+    /// <summary>
+    ///     Epic Field information
+    /// </summary>
+    [JsonObject]
+    public class EpicField
+    {
+        /// <summary>
+        ///     The Id for the Epic
+        /// </summary>
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        ///     The Label for the Epic
+        /// </summary>
+        [JsonProperty(PropertyName = "label")]
+        public string Label { get; set; }
+
+        /// <summary>
+        ///     Is the Epic editable?
+        /// </summary>
+        [JsonProperty(PropertyName = "editable")]
+        public bool Editable { get; set; }
+
+        /// <summary>
+        ///     Renderer for the Epic
+        /// </summary>
+        [JsonProperty(PropertyName = "renderer")]
+        public string Renderer { get; set; }
+        
+        /// <summary>
+        ///     The Key for the Epic
+        /// </summary>
+        [JsonProperty(PropertyName = "epicKey")]
+        public string EpicKey { get; set; }
+
+        /// <summary>
+        ///     The Color for the Epic
+        /// </summary>
+        [JsonProperty(PropertyName = "epicColor")]
+        public string EpicColor { get; set; }
+
+        /// <summary>
+        ///     The Text for the Epic
+        /// </summary>
+        [JsonProperty(PropertyName = "text")]
+        public string Text { get; set; }
+
+        /// <summary>
+        ///     Can the Epic be removed?
+        /// </summary>
+        [JsonProperty(PropertyName = "canRemoveEpic")]
+        public bool CanRemoveEpic { get; set; }
+    }
+}

--- a/src/Dapplo.Jira/Entities/ReportIssue.cs
+++ b/src/Dapplo.Jira/Entities/ReportIssue.cs
@@ -1,0 +1,99 @@
+﻿#region Dapplo 2017 - GNU Lesser General Public License
+
+// Dapplo - building blocks for .NET applications
+// Copyright (C) 2017 Dapplo
+// 
+// For more information see: http://dapplo.net/
+// Dapplo repositories are hosted on GitHub: https://github.com/dapplo
+// 
+// This file is part of Dapplo.Jira
+// 
+// Dapplo.Jira is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Dapplo.Jira is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have a copy of the GNU Lesser General Public License
+// along with Dapplo.Jira. If not, see <http://www.gnu.org/licenses/lgpl.txt>.
+
+#endregion
+
+#region Usings
+
+using System;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+#endregion
+
+
+namespace Dapplo.Jira.Entities
+{
+    /// <summary>
+    ///     Report Issue information
+    /// </summary>
+    [JsonObject]
+    public class ReportIssue : IssueBase
+    {
+        public long Id { get; set; }
+
+        public bool Hidden { get; set; }
+
+        public string TypeName { get; set; }
+
+        public string TypeId { get; set; }
+
+        public string Summary { get; set; }
+
+        public Uri TypeUrl { get; set; }
+
+        public Uri PriorityUrl { get; set; }
+
+        public string priorityName { get; set; }
+
+        public bool Done { get; set; }
+
+        public string Assignee { get; set; }
+
+        public string AssigneeKey { get; set; }
+
+        public Uri AvatarUrl { get; set; }
+
+        public bool HasCustomUserAvatar { get; set; }
+
+        public bool Flagged { get; set; }
+
+        public string Epic { get; set; }
+
+        public EpicField EpicField { get; set; }
+
+        public StatisticField ColumnStatistic { get; set; }
+
+        public StatisticField CurrentEstimateStatistic { get; set; }
+
+        public bool EstimateStatisticRequired { get; set; }
+
+        public StatisticField EstimateStatistic { get; set; }
+
+        public StatisticField TrackingStatistic { get; set; }
+
+        public string StatusId { get; set; }
+
+        public string StatusName { get; set; }
+
+        public Uri StatusUrl { get; set; }
+
+        public Status Status { get; set; }
+
+        public IEnumerable<string> FixVersions { get; set; }
+
+        public long ProjectId { get; set; }
+
+        public int LinkedPagesCount { get; set; }
+    }
+}

--- a/src/Dapplo.Jira/Entities/Sprint.cs
+++ b/src/Dapplo.Jira/Entities/Sprint.cs
@@ -28,6 +28,7 @@
 using System;
 using System.ComponentModel;
 using Newtonsoft.Json;
+using Dapplo.Jira.Json;
 
 #endregion
 
@@ -68,20 +69,23 @@ namespace Dapplo.Jira.Entities
 		/// </summary>
 		[JsonProperty(PropertyName = "startDate")]
 		[ReadOnly(true)]
-		public DateTimeOffset? StartDate { get; set; }
+        [JsonConverter(typeof(CustomDateTimeOffsetConverter))]
+        public DateTimeOffset? StartDate { get; set; }
 
 		/// <summary>
 		///     When was the sprint ended
 		/// </summary>
 		[JsonProperty(PropertyName = "endDate")]
 		[ReadOnly(true)]
-		public DateTimeOffset? EndDate { get; set; }
+        [JsonConverter(typeof(CustomDateTimeOffsetConverter))]
+        public DateTimeOffset? EndDate { get; set; }
 
 		/// <summary>
 		///     When was the sprint completed
 		/// </summary>
 		[JsonProperty(PropertyName = "completeDate")]
 		[ReadOnly(true)]
-		public DateTimeOffset? CompleteDate { get; set; }
+        [JsonConverter(typeof(CustomDateTimeOffsetConverter))]
+        public DateTimeOffset? CompleteDate { get; set; }
 	}
 }

--- a/src/Dapplo.Jira/Entities/SprintInReport.cs
+++ b/src/Dapplo.Jira/Entities/SprintInReport.cs
@@ -1,4 +1,4 @@
-#region Dapplo 2017 - GNU Lesser General Public License
+﻿#region Dapplo 2017 - GNU Lesser General Public License
 
 // Dapplo - building blocks for .NET applications
 // Copyright (C) 2017 Dapplo
@@ -23,33 +23,49 @@
 
 #endregion
 
-using System;
+#region Usings
 
-namespace Dapplo.Jira.Domains
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+#endregion
+
+namespace Dapplo.Jira.Entities
 {
     /// <summary>
-    ///     This interface describes the functionality of the IJiraClient which domains can use
+    ///     Sprint information within a Sprint Report
     /// </summary>
-    public interface IJiraDomain : IJiraClient
+    [JsonObject]
+    public class SprintInReport : Sprint
     {
         /// <summary>
-        ///     The rest URI for your JIRA server
+        ///     Sequence of this sprint
         /// </summary>
-        Uri JiraRestUri { get; }
+        [JsonProperty(PropertyName = "sequence")]
+        public long Sequence { get; set; }
 
         /// <summary>
-        ///     The agile rest URI for your JIRA server
+        ///     Indicates the amount of pages attached to the sprint
         /// </summary>
-        Uri JiraAgileRestUri { get; }
+        [JsonProperty(PropertyName = "linkedPagesCount")]
+        public int LinkedPagesCount { get; set; }
 
         /// <summary>
-        ///     The base URI for JIRA auth api
+        ///     Indicated if the Sprint can be updated
         /// </summary>
-        Uri JiraAuthUri { get; }
+        [JsonProperty(PropertyName = "canUpdateSprint")]
+        public bool CanUpdateSprint { get; set; }
 
         /// <summary>
-        ///     The greenhopper rest URI for your JIRA server
+        ///     Links to pages attached to the sprint
         /// </summary>
-        Uri JiraGreenhopperRestUri { get; }
+        [JsonProperty(PropertyName = "remoteLinks")]
+        public IEnumerable<string> RemoteLinks { get; set; }
+
+        /// <summary>
+        ///     Days remaining before the end of the sprint
+        /// </summary>
+        [JsonProperty(PropertyName = "daysRemaining")]
+        public int DaysRemaining { get; set; }
     }
 }

--- a/src/Dapplo.Jira/Entities/SprintReport.cs
+++ b/src/Dapplo.Jira/Entities/SprintReport.cs
@@ -1,4 +1,4 @@
-#region Dapplo 2017 - GNU Lesser General Public License
+﻿#region Dapplo 2017 - GNU Lesser General Public License
 
 // Dapplo - building blocks for .NET applications
 // Copyright (C) 2017 Dapplo
@@ -23,33 +23,36 @@
 
 #endregion
 
-using System;
+#region Usings
 
-namespace Dapplo.Jira.Domains
+using Newtonsoft.Json;
+
+#endregion
+
+namespace Dapplo.Jira.Entities
 {
     /// <summary>
-    ///     This interface describes the functionality of the IJiraClient which domains can use
+    ///     Grasshopper Sprint Report
     /// </summary>
-    public interface IJiraDomain : IJiraClient
+    [JsonObject]
+    public class SprintReport
     {
         /// <summary>
-        ///     The rest URI for your JIRA server
+        ///     The Sprint Report contents
         /// </summary>
-        Uri JiraRestUri { get; }
+        [JsonProperty(PropertyName = "contents")]
+        public SprintReportContents Contents { get; set; }
 
         /// <summary>
-        ///     The agile rest URI for your JIRA server
+        ///     Sprint information
         /// </summary>
-        Uri JiraAgileRestUri { get; }
+        [JsonProperty(PropertyName = "sprint")]
+        public SprintInReport Sprint { get; set; }
 
         /// <summary>
-        ///     The base URI for JIRA auth api
+        ///     Indicates if the sprint supports pages
         /// </summary>
-        Uri JiraAuthUri { get; }
-
-        /// <summary>
-        ///     The greenhopper rest URI for your JIRA server
-        /// </summary>
-        Uri JiraGreenhopperRestUri { get; }
+        [JsonProperty(PropertyName = "supportsPages")]
+        public bool SupportsPages { get; set; }
     }
 }

--- a/src/Dapplo.Jira/Entities/SprintReportContents.cs
+++ b/src/Dapplo.Jira/Entities/SprintReportContents.cs
@@ -1,0 +1,125 @@
+﻿#region Dapplo 2017 - GNU Lesser General Public License
+
+// Dapplo - building blocks for .NET applications
+// Copyright (C) 2017 Dapplo
+// 
+// For more information see: http://dapplo.net/
+// Dapplo repositories are hosted on GitHub: https://github.com/dapplo
+// 
+// This file is part of Dapplo.Jira
+// 
+// Dapplo.Jira is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Dapplo.Jira is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have a copy of the GNU Lesser General Public License
+// along with Dapplo.Jira. If not, see <http://www.gnu.org/licenses/lgpl.txt>.
+
+#endregion
+
+#region Usings
+
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+#endregion
+
+namespace Dapplo.Jira.Entities
+{
+    /// <summary>
+    ///     Grasshopper Sprint Report
+    /// </summary>
+    [JsonObject]
+    public class SprintReportContents
+    {
+        /// <summary>
+        ///     The Completed Issues on the sprint
+        /// </summary>
+        [JsonProperty(PropertyName = "completedIssues")]
+        public IEnumerable<ReportIssue> CompletedIssues { get; set; }
+
+        /// <summary>
+        ///     The Issues Non Completed on the sprint
+        /// </summary>
+        [JsonProperty(PropertyName = "issuesNotCompletedInCurrentSprint")]
+        public IEnumerable<ReportIssue> IssuesNotCompletedInCurrentSprint { get; set; }
+
+        /// <summary>
+        ///     The Puntes Issues on the sprint
+        /// </summary>
+        [JsonProperty(PropertyName = "puntedIssues")]
+        public IEnumerable<ReportIssue> PuntedIssues { get; set; }
+
+        /// <summary>
+        ///     The Issues Completed on another sprint
+        /// </summary>
+        [JsonProperty(PropertyName = "issuesCompletedInAnotherSprint")]
+        public IEnumerable<ReportIssue> IssuesCompletedInAnotherSprint { get; set; }
+
+        /// <summary>
+        ///     Initial Estimate sum for completed issues
+        /// </summary>
+        [JsonProperty(PropertyName = "completedIssuesInitialEstimateSum")]
+        public ValueField CompletedIssuesInitialEstimateSum { get; set; }
+
+        /// <summary>
+        ///     Estimate sum for completed issues
+        /// </summary>
+        [JsonProperty(PropertyName = "completedIssuesEstimateSum")]
+        public ValueField CompletedIssuesEstimateSum { get; set; }
+
+        /// <summary>
+        ///     Initial Estimate sum for issues not completed
+        /// </summary>
+        [JsonProperty(PropertyName = "issuesNotCompletedInitialEstimateSum")]
+        public ValueField IssuesNotCompletedInitialEstimateSum { get; set; }
+
+        /// <summary>
+        ///     Estimate sum for issues not completed
+        /// </summary>
+        [JsonProperty(PropertyName = "issuesNotCompletedEstimateSum")]
+        public ValueField IssuesNotCompletedEstimateSum { get; set; }
+
+        /// <summary>
+        ///     Estimate sum for all issues
+        /// </summary>
+        [JsonProperty(PropertyName = "allIssuesEstimateSum")]
+        public ValueField AllIssuesEstimateSum { get; set; }
+
+        /// <summary>
+        ///     Initial Estimate sum for punted issues
+        /// </summary>
+        [JsonProperty(PropertyName = "puntedIssuesInitialEstimateSum")]
+        public ValueField PuntedIssuesInitialEstimateSum { get; set; }
+
+        /// <summary>
+        ///     Estimate sum for punted issues
+        /// </summary>
+        [JsonProperty(PropertyName = "puntedIssuesEstimateSum")]
+        public ValueField PuntedIssuesEstimateSum { get; set; }
+
+        /// <summary>
+        ///     Initial Estimate sum for issues completed in another sprint
+        /// </summary>
+        [JsonProperty(PropertyName = "issuesCompletedInAnotherSprintInitialEstimateSum")]
+        public ValueField IssuesCompletedInAnotherSprintInitialEstimateSum { get; set; }
+
+        /// <summary>
+        ///     Estimate sum for issues completed in another sprint
+        /// </summary>
+        [JsonProperty(PropertyName = "issuesCompletedInAnotherSprintEstimateSum")]
+        public ValueField IssuesCompletedInAnotherSprintEstimateSum { get; set; }
+
+        /// <summary>
+        ///     Keys for Issues added during the sprint
+        /// </summary>
+        [JsonProperty(PropertyName = "issueKeysAddedDuringSprint")]
+        public Dictionary<string, bool> IssueKeysAddedDuringSprint { get; set; }
+    }
+}

--- a/src/Dapplo.Jira/Entities/StatisticField.cs
+++ b/src/Dapplo.Jira/Entities/StatisticField.cs
@@ -1,4 +1,4 @@
-#region Dapplo 2017 - GNU Lesser General Public License
+﻿#region Dapplo 2017 - GNU Lesser General Public License
 
 // Dapplo - building blocks for .NET applications
 // Copyright (C) 2017 Dapplo
@@ -23,33 +23,30 @@
 
 #endregion
 
-using System;
+#region Usings
 
-namespace Dapplo.Jira.Domains
+using Newtonsoft.Json;
+
+#endregion
+
+namespace Dapplo.Jira.Entities
 {
     /// <summary>
-    ///     This interface describes the functionality of the IJiraClient which domains can use
+    ///     Statistic Field information
     /// </summary>
-    public interface IJiraDomain : IJiraClient
+    [JsonObject]
+    public class StatisticField
     {
         /// <summary>
-        ///     The rest URI for your JIRA server
+        ///     The Statistic Field Id
         /// </summary>
-        Uri JiraRestUri { get; }
+        [JsonProperty(PropertyName = "statFieldId")]
+        public string StatFieldId { get; set; }
 
         /// <summary>
-        ///     The agile rest URI for your JIRA server
+        ///     The Statistic Field value
         /// </summary>
-        Uri JiraAgileRestUri { get; }
-
-        /// <summary>
-        ///     The base URI for JIRA auth api
-        /// </summary>
-        Uri JiraAuthUri { get; }
-
-        /// <summary>
-        ///     The greenhopper rest URI for your JIRA server
-        /// </summary>
-        Uri JiraGreenhopperRestUri { get; }
+        [JsonProperty(PropertyName = "tatFieldValue")]
+        public ValueField StatFieldValue { get; set; }
     }
 }

--- a/src/Dapplo.Jira/Entities/ValueField.cs
+++ b/src/Dapplo.Jira/Entities/ValueField.cs
@@ -1,4 +1,4 @@
-#region Dapplo 2017 - GNU Lesser General Public License
+﻿#region Dapplo 2017 - GNU Lesser General Public License
 
 // Dapplo - building blocks for .NET applications
 // Copyright (C) 2017 Dapplo
@@ -23,33 +23,30 @@
 
 #endregion
 
-using System;
+#region Usings
 
-namespace Dapplo.Jira.Domains
+using Newtonsoft.Json;
+
+#endregion
+
+namespace Dapplo.Jira.Entities
 {
     /// <summary>
-    ///     This interface describes the functionality of the IJiraClient which domains can use
+    ///     Represents Values in numeric and string modes
     /// </summary>
-    public interface IJiraDomain : IJiraClient
+    [JsonObject]
+    public class ValueField
     {
         /// <summary>
-        ///     The rest URI for your JIRA server
+        ///     The numeric value
         /// </summary>
-        Uri JiraRestUri { get; }
+        [JsonProperty(PropertyName = "value")]
+        public long Value { get; set; }
 
         /// <summary>
-        ///     The agile rest URI for your JIRA server
+        ///     The string value
         /// </summary>
-        Uri JiraAgileRestUri { get; }
-
-        /// <summary>
-        ///     The base URI for JIRA auth api
-        /// </summary>
-        Uri JiraAuthUri { get; }
-
-        /// <summary>
-        ///     The greenhopper rest URI for your JIRA server
-        /// </summary>
-        Uri JiraGreenhopperRestUri { get; }
+        [JsonProperty(PropertyName = "text")]
+        public string Text { get; set; }
     }
 }

--- a/src/Dapplo.Jira/GreenhopperExtensions.cs
+++ b/src/Dapplo.Jira/GreenhopperExtensions.cs
@@ -1,0 +1,65 @@
+﻿#region Dapplo 2017 - GNU Lesser General Public License
+
+// Dapplo - building blocks for .NET applications
+// Copyright (C) 2017 Dapplo
+// 
+// For more information see: http://dapplo.net/
+// Dapplo repositories are hosted on GitHub: https://github.com/dapplo
+// 
+// This file is part of Dapplo.Jira
+// 
+// Dapplo.Jira is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// Dapplo.Jira is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have a copy of the GNU Lesser General Public License
+// along with Dapplo.Jira. If not, see <http://www.gnu.org/licenses/lgpl.txt>.
+
+#endregion
+
+#region Usings
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapplo.HttpExtensions;
+using Dapplo.Jira.Domains;
+using Dapplo.Jira.Entities;
+using Dapplo.Jira.Internal;
+
+#endregion
+
+namespace Dapplo.Jira
+{
+    /// <summary>
+    ///     This holds all the greenhopper related extensions methods
+    /// </summary>
+    public static class GreenhopperExtensions
+    {
+        /// <summary>
+        ///     Get the sprint report for the desired sprint in the context of the target board.
+        ///     See: <i>Not documented endpont</i>
+        ///     Endpoint pattern: https://{domain}.atlassian.net/rest/greenhopper/1.0/rapid/charts/sprintreport?rapidViewId={rapidViewId}&sprintId={sprintId}
+        /// </summary>
+        /// <param name="jiraClient">IGreenhopperDomain to bind the extension method to</param>
+        /// <param name="rapidViewId">key for the target board</param>
+        /// <param name="sprintId">key for the desired sprint</param>
+        /// /// <param name="cancellationToken">CancellationToken</param>
+        /// <returns></returns>
+        public static async Task<SprintReport> GetSprintReportAsync(this IGreenhopperDomain jiraClient, long rapidViewId, long sprintId, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            jiraClient.Behaviour.MakeCurrent();
+            var sprintReportUri = jiraClient.JiraGreenhopperRestUri.AppendSegments("rapid", "charts", "sprintreport")
+                                        .ExtendQuery("rapidViewId", rapidViewId)
+                                        .ExtendQuery("sprintId", sprintId);
+            var response = await sprintReportUri.GetAsAsync<HttpResponse<SprintReport, Error>>(cancellationToken).ConfigureAwait(false);
+            return response.HandleErrors();
+        }
+    }
+}

--- a/src/Dapplo.Jira/IJiraClient.cs
+++ b/src/Dapplo.Jira/IJiraClient.cs
@@ -89,10 +89,15 @@ namespace Dapplo.Jira
 		/// </summary>
 		IServerDomain Server { get; }
 
-		/// <summary>
-		///     Agile domain
+        /// <summary>
+        ///     Agile domain
+        /// </summary>
+        IAgileDomain Agile { get; }
+
+        /// <summary>
+		///     Grasshopper domain
 		/// </summary>
-		IAgileDomain Agile { get; }
+        IGreenhopperDomain Greenhopper { get; }
 
 		/// <summary>
 		///     Set Basic Authentication for the current client

--- a/src/Dapplo.Jira/JiraClient.cs
+++ b/src/Dapplo.Jira/JiraClient.cs
@@ -46,7 +46,7 @@ namespace Dapplo.Jira
     /// <summary>
     ///     A client for accessing the Atlassian JIRA Api via REST, using Dapplo.HttpExtensions
     /// </summary>
-    public class JiraClient : IProjectDomain, IWorkDomain, IUserDomain, ISessionDomain, IIssueDomain, IFilterDomain, IAttachmentDomain, IServerDomain, IAgileDomain
+    public class JiraClient : IProjectDomain, IWorkDomain, IUserDomain, ISessionDomain, IIssueDomain, IFilterDomain, IAttachmentDomain, IServerDomain, IAgileDomain, IGreenhopperDomain
     {
         private string _password;
         private string _user;
@@ -78,6 +78,7 @@ namespace Dapplo.Jira
             JiraRestUri = baseUri.AppendSegments("rest", "api", "2");
             JiraAuthUri = baseUri.AppendSegments("rest", "auth", "1");
             JiraAgileRestUri = baseUri.AppendSegments("rest", "agile", "1.0");
+            JiraGreenhopperRestUri = baseUri.AppendSegments("rest", "greenhopper", "1.0");
         }
 
 #if NET45 || NET46
@@ -169,6 +170,11 @@ namespace Dapplo.Jira
         public Uri JiraAgileRestUri { get; }
 
         /// <summary>
+        ///     The greenhopper rest URI for your JIRA server
+        /// </summary>
+        public Uri JiraGreenhopperRestUri { get; }
+
+        /// <summary>
         ///     The base URI for JIRA auth api
         /// </summary>
         public Uri JiraAuthUri { get; }
@@ -224,10 +230,14 @@ namespace Dapplo.Jira
         /// </summary>
         public IServerDomain Server => this;
 
-
         /// <summary>
         ///     Agile domain
         /// </summary>
         public IAgileDomain Agile => this;
+
+        /// <summary>
+        ///     Greenhopper domain
+        /// </summary>
+        public IGreenhopperDomain Greenhopper => this;
     }
 }

--- a/src/Dapplo.Jira/Json/CustomDateTimeOffsetConverter.cs
+++ b/src/Dapplo.Jira/Json/CustomDateTimeOffsetConverter.cs
@@ -82,6 +82,10 @@ namespace Dapplo.Jira.Json
             {
                 throw new Exception($"Unexpected token parsing date. Expected string, got {reader.TokenType}.");
             }
+            if (dateTimeOffsetString.ToLowerInvariant() == "none")
+            {
+                return null;
+            }
             if (Regex.IsMatch(dateTimeOffsetString, @"\d{4}$"))
             {
                 dateTimeOffsetString = dateTimeOffsetString.Insert(dateTimeOffsetString.Length - 2, ":");


### PR DESCRIPTION
Hi
I have added a new domain called GreenhopperDomain. This is used for fetching the SprintReport. As of today, this SprintReport API endpoint is nowhere documented but I managed to make and test Domain for it on your library.
I am using this domain and call in an internal project for my company. I would kindly appreciate if you accept this Pull Request so I no longer have to reference my version of you great API.
Kind Regards
Hector HERNANDEZ