### PR TITLE
Fixed SprintInReport's remote links issue by adding RemoteLinks object 

### DIFF
--- a/src/Dapplo.Jira/Entities/RemoteLinks.cs
+++ b/src/Dapplo.Jira/Entities/RemoteLinks.cs
@@ -25,47 +25,29 @@
 
 #region Usings
 
+using System;
 using Newtonsoft.Json;
-using System.Collections.Generic;
 
 #endregion
 
 namespace Dapplo.Jira.Entities
 {
     /// <summary>
-    ///     Sprint information within a Sprint Report
+    ///     Remote Links
     /// </summary>
     [JsonObject]
-    public class SprintInReport : Sprint
+    public class RemoteLinks
     {
         /// <summary>
-        ///     Sequence of this sprint
+        ///     Remote link title or type
         /// </summary>
-        [JsonProperty(PropertyName = "sequence")]
-        public long Sequence { get; set; }
+        [JsonProperty(PropertyName = "title")]
+        public string Title { get; set; }
 
         /// <summary>
-        ///     Indicates the amount of pages attached to the sprint
+        ///     Remote link url
         /// </summary>
-        [JsonProperty(PropertyName = "linkedPagesCount")]
-        public int LinkedPagesCount { get; set; }
-
-        /// <summary>
-        ///     Indicated if the Sprint can be updated
-        /// </summary>
-        [JsonProperty(PropertyName = "canUpdateSprint")]
-        public bool CanUpdateSprint { get; set; }
-
-        /// <summary>
-        ///     Links to pages attached to the sprint
-        /// </summary>
-        [JsonProperty(PropertyName = "remoteLinks")]
-        public IEnumerable<RemoteLinks> RemoteLinks { get; set; }
-
-        /// <summary>
-        ///     Days remaining before the end of the sprint
-        /// </summary>
-        [JsonProperty(PropertyName = "daysRemaining")]
-        public int DaysRemaining { get; set; }
+        [JsonProperty(PropertyName = "url")]
+        public Uri Url { get; set; }
     }
 }

--- a/src/Dapplo.Jira/Entities/ReportIssue.cs
+++ b/src/Dapplo.Jira/Entities/ReportIssue.cs
@@ -40,123 +40,147 @@ namespace Dapplo.Jira.Entities
     public class ReportIssue : IssueBase
     {
         /// <summary>
-        /// Is this issue hidden?
+        ///     Is this issue hidden?
         /// </summary>
+        [JsonProperty(PropertyName = "hidden")]
         public bool Hidden { get; set; }
 
         /// <summary>
-        /// Name of the type
+        ///     Name of the type
         /// </summary>
+        [JsonProperty(PropertyName = "typeName")]
         public string TypeName { get; set; }
 
         /// <summary>
-        /// Type ID for the issue
+        ///     Type ID for the issue
         /// </summary>
+        [JsonProperty(PropertyName = "typeId")]
         public string TypeId { get; set; }
 
         /// <summary>
-        /// Issue summary
+        ///     Issue summary
         /// </summary>
+        [JsonProperty(PropertyName = "summary")]
         public string Summary { get; set; }
 
         /// <summary>
-        /// Url to the type of issue
+        ///     Url to the type of issue
         /// </summary>
+        [JsonProperty(PropertyName = "typeUrl")]
         public Uri TypeUrl { get; set; }
 
         /// <summary>
-        /// Url to the priority
+        ///     Url to the priority
         /// </summary>
+        [JsonProperty(PropertyName = "priorityUrl")]
         public Uri PriorityUrl { get; set; }
 
         /// <summary>
-        /// Name of the priority
+        ///     Name of the priority
         /// </summary>
+        [JsonProperty(PropertyName = "priorityName")]
         public string PriorityName { get; set; }
 
         /// <summary>
-        /// Is the issue done?
+        ///     Is the issue done?
         /// </summary>
+        [JsonProperty(PropertyName = "done")]
         public bool Done { get; set; }
 
         /// <summary>
-        /// Who is this issue assigned to?
+        ///     Who is this issue assigned to?
         /// </summary>
+        [JsonProperty(PropertyName = "assignee")]
         public string Assignee { get; set; }
 
         /// <summary>
-        /// Key of the person this issue is assigned to
+        ///     Key of the person this issue is assigned to
         /// </summary>
+        [JsonProperty(PropertyName = "assigneeKey")]
         public string AssigneeKey { get; set; }
 
         /// <summary>
-        /// Uri to the avatar of the current user
+        ///     Uri to the avatar of the current user
         /// </summary>
+        [JsonProperty(PropertyName = "avatarUrl")]
         public Uri AvatarUrl { get; set; }
 
         /// <summary>
-        /// Does user have a customavatar?
+        ///     Does user have a customavatar?
         /// </summary>
+        [JsonProperty(PropertyName = "hasCustomUserAvatar")]
         public bool HasCustomUserAvatar { get; set; }
 
         /// <summary>
-        /// Is this issue flagged?
+        ///     Is this issue flagged?
         /// </summary>
+        [JsonProperty(PropertyName = "flagged")]
         public bool Flagged { get; set; }
 
         /// <summary>
-        /// The epic this issue belongs to
+        ///     The epic this issue belongs to
         /// </summary>
+        [JsonProperty(PropertyName = "epic")]
         public string Epic { get; set; }
 
         /// <summary>
-        /// The epic field
+        ///     The epic field
         /// </summary>
+        [JsonProperty(PropertyName = "epicField")]
         public EpicField EpicField { get; set; }
 
         /// <summary>
-        /// The statics for the colum
+        ///     The statics for the colum
         /// </summary>
+        [JsonProperty(PropertyName = "columnStatistic")]
         public StatisticField ColumnStatistic { get; set; }
 
         /// <summary>
-        /// Current estimate
+        ///     Current estimate
         /// </summary>
+        [JsonProperty(PropertyName = "currentEstimateStatistic")]
         public StatisticField CurrentEstimateStatistic { get; set; }
 
         /// <summary>
-        /// Tells if the estimate statistics are required
+        ///     Tells if the estimate statistics are required
         /// </summary>
+        [JsonProperty(PropertyName = "estimateStatisticRequired")]
         public bool EstimateStatisticRequired { get; set; }
 
         /// <summary>
-        /// Estimate statistics
+        ///     Estimate statistics
         /// </summary>
+        [JsonProperty(PropertyName = "estimateStatistic")]
         public StatisticField EstimateStatistic { get; set; }
 
         /// <summary>
-        /// Tracking statistics
+        ///     Tracking statistics
         /// </summary>
+        [JsonProperty(PropertyName = "trackingStatistic")]
         public StatisticField TrackingStatistic { get; set; }
 
         /// <summary>
-        /// Status of the issue
+        ///     Status of the issue
         /// </summary>
+        [JsonProperty(PropertyName = "status")]
         public Status Status { get; set; }
 
         /// <summary>
-        /// Versions in which this issue is fixed
+        ///     Versions in which this issue is fixed
         /// </summary>
+        [JsonProperty(PropertyName = "fixVersions")]
         public IEnumerable<string> FixVersions { get; set; }
 
         /// <summary>
-        /// Project where the issue belongs to
+        ///     Project where the issue belongs to
         /// </summary>
+        [JsonProperty(PropertyName = "projectId")]
         public long ProjectId { get; set; }
 
         /// <summary>
-        /// Number of linked pages, used to display the count of pages for the sprint.
+        ///     Number of linked pages, used to display the count of pages for the sprint.
         /// </summary>
+        [JsonProperty(PropertyName = "linkedPagesCount")]
         public int LinkedPagesCount { get; set; }
     }
 }


### PR DESCRIPTION
Hi again,

In this pull request I am fixing an issue I have found while retrieving a sprint report. The issues is that the Sprint RemoteLinks were actually a complex object rather than a list of strings.

Thanks,
HH