### PR TITLE
Feature/changelogs integration

### DIFF
--- a/src/Dapplo.Jira.Tests/IssueTests.cs
+++ b/src/Dapplo.Jira.Tests/IssueTests.cs
@@ -143,7 +143,8 @@ namespace Dapplo.Jira.Tests
 		[Fact]
 		public async Task TestSearch()
 		{
-			var searchResult = await Client.Issue.SearchAsync(Where.Text.Contains("robin"));
+			var searchResult =
+				await Client.Issue.SearchAsync(Where.Text.Contains("robin"));
 
 			Assert.NotNull(searchResult);
 			Assert.True(searchResult.Issues.Count > 0);
@@ -151,32 +152,48 @@ namespace Dapplo.Jira.Tests
 			foreach (var issue in searchResult.Issues)
 			{
 				Assert.NotNull(issue.Fields.Project);
+				Assert.Null(issue.Changelog); //Should be null as no changelog was requested in the request
 			}
 		}
 
-	    [Fact]
-	    public async Task TestSearch_Paging()
-	    {
-	        // Create initial search
-	        string[] fields = { "summary", "status", "assignee", "key", "project", "summary" };
-	        var searchResult = await Client.Issue.SearchAsync(Where.Text.Contains("DPI"), fields: fields);
-	        // Loop over all results
-	        while (searchResult.Count > 0)
-	        {
-	            Assert.NotNull(searchResult);
-	            Assert.True(searchResult.Issues.Count > 0);
-	            Log.Info().WriteLine("Got {0} of {1} results, starting at index {2}, isLast: {3}", searchResult.Count, searchResult.Total, searchResult.StartAt, searchResult.IsLastPage);
-	            foreach (var issue in searchResult)
-	            {
-	                Log.Info().WriteLine("Found issue {0} - {1}", issue.Key, issue.Fields.Summary);
-	            }
-	            if (searchResult.IsLastPage)
-	            {
-	                break;
-	            }
-	            // Continue the search, by reusing the SearchParameter and taking the next page
-	            searchResult = await Client.Issue.SearchAsync(searchResult.SearchParameter, searchResult.NextPage);
-	        }
-	    }
-    }
+		[Fact]
+		public async Task TestSearch_Paging()
+		{
+			// Create initial search
+			string[] fields = {"summary", "status", "assignee", "key", "project", "summary"};
+			var searchResult =
+				await Client.Issue.SearchAsync(Where.Text.Contains("DPI"), fields: fields);
+			// Loop over all results
+			while (searchResult.Count > 0)
+			{
+				Assert.NotNull(searchResult);
+				Assert.True(searchResult.Issues.Count > 0);
+				Log.Info().WriteLine("Got {0} of {1} results, starting at index {2}, isLast: {3}", searchResult.Count,
+					searchResult.Total, searchResult.StartAt, searchResult.IsLastPage);
+				foreach (var issue in searchResult)
+					Log.Info().WriteLine("Found issue {0} - {1}", issue.Key, issue.Fields.Summary);
+				if (searchResult.IsLastPage)
+				{
+					break;
+				}
+				// Continue the search, by reusing the SearchParameter and taking the next page
+				searchResult = await Client.Issue.SearchAsync(searchResult.SearchParameter, searchResult.NextPage);
+			}
+		}
+
+		[Fact]
+		public async Task TestSearchWithChangelog()
+		{
+			var searchResult = await Client.Issue.SearchAsync(Where.Text.Contains("robin"), expand: new[] {"changelog"});
+
+			Assert.NotNull(searchResult);
+			Assert.True(searchResult.Issues.Count > 0);
+
+			foreach (var issue in searchResult.Issues)
+			{
+				Assert.NotNull(issue.Fields.Project);
+				Assert.NotNull(issue.Changelog);
+			}
+		}
+	}
 }

--- a/src/Dapplo.Jira.Tests/IssueTests.cs
+++ b/src/Dapplo.Jira.Tests/IssueTests.cs
@@ -143,8 +143,7 @@ namespace Dapplo.Jira.Tests
 		[Fact]
 		public async Task TestSearch()
 		{
-			var searchResult =
-				await Client.Issue.SearchAsync(Where.Text.Contains("robin"));
+			var searchResult = await Client.Issue.SearchAsync(Where.Text.Contains("robin"));
 
 			Assert.NotNull(searchResult);
 			Assert.True(searchResult.Issues.Count > 0);

--- a/src/Dapplo.Jira.Tests/IssueTests.cs
+++ b/src/Dapplo.Jira.Tests/IssueTests.cs
@@ -161,17 +161,17 @@ namespace Dapplo.Jira.Tests
 		{
 			// Create initial search
 			string[] fields = {"summary", "status", "assignee", "key", "project", "summary"};
-			var searchResult =
-				await Client.Issue.SearchAsync(Where.Text.Contains("DPI"), fields: fields);
+			var searchResult = await Client.Issue.SearchAsync(Where.Text.Contains("DPI"), fields: fields);
 			// Loop over all results
 			while (searchResult.Count > 0)
 			{
 				Assert.NotNull(searchResult);
 				Assert.True(searchResult.Issues.Count > 0);
-				Log.Info().WriteLine("Got {0} of {1} results, starting at index {2}, isLast: {3}", searchResult.Count,
-					searchResult.Total, searchResult.StartAt, searchResult.IsLastPage);
+				Log.Info().WriteLine("Got {0} of {1} results, starting at index {2}, isLast: {3}", searchResult.Count, searchResult.Total, searchResult.StartAt, searchResult.IsLastPage);
 				foreach (var issue in searchResult)
+				{
 					Log.Info().WriteLine("Found issue {0} - {1}", issue.Key, issue.Fields.Summary);
+				}
 				if (searchResult.IsLastPage)
 				{
 					break;

--- a/src/Dapplo.Jira/Entities/Changelog.cs
+++ b/src/Dapplo.Jira/Entities/Changelog.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Dapplo.Jira.Entities
+{
+	/// <summary>
+	///     Changelog informations
+	/// </summary>
+	/// <seealso cref="Dapplo.Jira.Entities.PageableResult" />
+	[JsonObject]
+	public class Changelog : PageableResult
+	{
+		/// <summary>
+		///     The actual history in changelog
+		/// </summary>
+		[JsonProperty("histories")]
+		public IList<History> Elements { get; set; }
+	}
+}

--- a/src/Dapplo.Jira/Entities/FieldType.cs
+++ b/src/Dapplo.Jira/Entities/FieldType.cs
@@ -1,0 +1,23 @@
+﻿namespace Dapplo.Jira.Entities
+{
+	/// <summary>
+	///     Represent the kind of field.
+	/// </summary>
+	public enum FieldType
+	{
+		/// <summary>
+		///     To be able to know if the field type has not been detected
+		/// </summary>
+		Unknown = 0,
+
+		/// <summary>
+		///     For the JIRA base fields types
+		/// </summary>
+		Jira = 1,
+
+		/// <summary>
+		///     For the Custom fields types
+		/// </summary>
+		Custom = 2
+	}
+}

--- a/src/Dapplo.Jira/Entities/History.cs
+++ b/src/Dapplo.Jira/Entities/History.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Newtonsoft.Json;
+
+namespace Dapplo.Jira.Entities
+{
+	[JsonObject]
+	public class History : BaseProperties<long>
+	{
+		/// <summary>
+		///     Who created the comment
+		/// </summary>
+		[JsonProperty("author")]
+		[ReadOnly(true)]
+		public User Author { get; set; }
+
+		/// <summary>
+		///     When was the comment created
+		/// </summary>
+		[JsonProperty("created")]
+		[ReadOnly(true)]
+		public DateTimeOffset? Created { get; set; }
+
+		/// <summary>
+		///     list of fields that have been changed during this operation
+		/// </summary>
+		/// <value>
+		///     The items.
+		/// </value>
+		[JsonProperty("items")]
+		[ReadOnly(true)]
+		public IList<HistoryItem> Items { get; set; }
+	}
+}

--- a/src/Dapplo.Jira/Entities/HistoryItem.cs
+++ b/src/Dapplo.Jira/Entities/HistoryItem.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Dapplo.Jira.Entities
+{
+	/// <summary>
+	/// One change on one specific field of one item
+	/// </summary>
+	[JsonObject]
+    public class HistoryItem
+    {
+		/// <summary>
+		/// Gets or sets the field.
+		/// </summary>
+		/// <value>
+		/// The field.
+		/// </value>
+		[JsonProperty("field")]
+	    [ReadOnly(true)]
+	    public string Field { get; set; }
+
+		/// <summary>
+		/// Gets or sets the type of the field.
+		/// </summary>
+		/// <value>
+		/// The type of the field.
+		/// </value>
+		[JsonProperty("fieldtype")]
+	    [ReadOnly(true)]
+		[JsonConverter(typeof(StringEnumConverter))]
+		public FieldType FieldType { get; set; }
+
+		/// <summary>
+		/// The from value value of JIRA. Could be a number, string, ... depending of the type
+		/// </summary>
+		/// <value>
+		/// From.
+		/// </value>
+		[JsonProperty("from")]
+		[ReadOnly(true)]
+		public string From { get; set; }
+
+		/// <summary>
+		/// A string representation of the from value of JIRA
+		/// </summary>
+		/// <value>
+		/// From string.
+		/// </value>
+		[JsonProperty("fromString")]
+		[ReadOnly(true)]
+		public string FromString { get; set; }
+
+		/// <summary>
+		/// The to value value of JIRA. Could be a number, string, ... depending of the type
+		/// </summary>
+		/// <value>
+		/// From.
+		/// </value>
+		[JsonProperty("to")]
+		[ReadOnly(true)]
+		public string To { get; set; }
+
+		/// <summary>
+		/// A string representation of the from value of JIRA
+		/// </summary>
+		/// <value>
+		/// From string.
+		/// </value>
+		[JsonProperty("toString")]
+		[ReadOnly(true)]
+		public string ToString { get; set; }
+    }
+}

--- a/src/Dapplo.Jira/Entities/IssueBase.cs
+++ b/src/Dapplo.Jira/Entities/IssueBase.cs
@@ -43,5 +43,14 @@ namespace Dapplo.Jira.Entities
 		/// </summary>
 		[JsonProperty("key")]
 		public string Key { get; set; }
+
+		/// <summary>
+		///     Gets or sets the changelogs.
+		/// </summary>
+		/// <value>
+		///     The changelogs.
+		/// </value>
+		[JsonProperty("changelog")]
+		public Changelog Changelog { get; set; }
 	}
 }

--- a/src/Dapplo.Jira/Entities/JqlIssueSearch.cs
+++ b/src/Dapplo.Jira/Entities/JqlIssueSearch.cs
@@ -38,22 +38,33 @@ namespace Dapplo.Jira.Entities
 	[JsonObject]
 	public class JqlIssueSearch : Page
 	{
-	    /// <summary>
-	    ///     Expand values
-	    /// </summary>
-	    [JsonProperty("expand")]
-	    public string Expand { get; set; } = JiraConfig.ExpandSearch == null ? null: string.Join(",", JiraConfig.ExpandSearch);
+		/// <summary>
+		///     Initializes a new instance of the <see cref="JqlIssueSearch" /> class.
+		/// </summary>
+		public JqlIssueSearch()
+		{
+			Expand = JiraConfig.ExpandSearch;
+		}
 
-        /// <summary>
-        ///     Fields for this query
-        /// </summary>
-        [JsonProperty("fields")]
+		/// <summary>
+		///     Expand values
+		/// </summary>
+		/// <value>
+		///     The expands.
+		/// </value>
+		[JsonProperty("expand")]
+		public IEnumerable<string> Expand { get; set; }
+
+		/// <summary>
+		///     Fields for this query
+		/// </summary>
+		[JsonProperty("fields")]
 		public IEnumerable<string> Fields { get; set; } = new List<string>(JiraConfig.SearchFields);
 
-        /// <summary>
-        ///     The JQL for this search
-        /// </summary>
-        [JsonProperty("jql")]
+		/// <summary>
+		///     The JQL for this search
+		/// </summary>
+		[JsonProperty("jql")]
 		public string Jql { get; set; }
 
 		/// <summary>

--- a/src/Dapplo.Jira/IssueExtensions.cs
+++ b/src/Dapplo.Jira/IssueExtensions.cs
@@ -41,378 +41,394 @@ using Dapplo.Log;
 
 namespace Dapplo.Jira
 {
-    /// <summary>
-    ///     This holds all the issue related extensions methods
-    /// </summary>
-    public static class IssueExtensions
-    {
-        private static readonly LogSource Log = new LogSource();
+	/// <summary>
+	///     This holds all the issue related extensions methods
+	/// </summary>
+	public static class IssueExtensions
+	{
+		private static readonly LogSource Log = new LogSource();
 
-        /// <summary>
-        ///     Add comment to the specified issue
-        ///     See: https://docs.atlassian.com/jira/REST/latest/#d2e1139
-        /// </summary>
-        /// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
-        /// <param name="issueKey">key for the issue</param>
-        /// <param name="body">the body of the comment</param>
-        /// <param name="visibility">optional visibility role</param>
-        /// <param name="cancellationToken">CancellationToken</param>
-        /// <returns>Comment</returns>
-        public static async Task<Comment> AddCommentAsync(this IIssueDomain jiraClient, string issueKey, string body, string visibility = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (issueKey == null)
-            {
-                throw new ArgumentNullException(nameof(issueKey));
-            }
-            Log.Debug().WriteLine("Adding comment to {0}", issueKey);
-            var comment = new Comment
-            {
-                Body = body,
-                Visibility = visibility == null
-                    ? null
-                    : new Visibility
-                    {
-                        Type = "role",
-                        Value = visibility
-                    }
-            };
-            jiraClient.Behaviour.MakeCurrent();
-            var attachUri = jiraClient.JiraRestUri.AppendSegments("issue", issueKey, "comment");
-            var response = await attachUri.PostAsync<HttpResponse<Comment, Error>>(comment, cancellationToken).ConfigureAwait(false);
-            return response.HandleErrors(HttpStatusCode.Created);
-        }
+		/// <summary>
+		///     Add comment to the specified issue
+		///     See: https://docs.atlassian.com/jira/REST/latest/#d2e1139
+		/// </summary>
+		/// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
+		/// <param name="issueKey">key for the issue</param>
+		/// <param name="body">the body of the comment</param>
+		/// <param name="visibility">optional visibility role</param>
+		/// <param name="cancellationToken">CancellationToken</param>
+		/// <returns>Comment</returns>
+		public static async Task<Comment> AddCommentAsync(this IIssueDomain jiraClient, string issueKey, string body, string visibility = null,
+			CancellationToken cancellationToken = default)
+		{
+			if (issueKey == null)
+			{
+				throw new ArgumentNullException(nameof(issueKey));
+			}
+			Log.Debug().WriteLine("Adding comment to {0}", issueKey);
+			var comment = new Comment
+			{
+				Body = body,
+				Visibility = visibility == null
+					? null
+					: new Visibility
+					{
+						Type = "role",
+						Value = visibility
+					}
+			};
+			jiraClient.Behaviour.MakeCurrent();
+			var attachUri = jiraClient.JiraRestUri.AppendSegments("issue", issueKey, "comment");
+			var response = await attachUri.PostAsync<HttpResponse<Comment, Error>>(comment, cancellationToken).ConfigureAwait(false);
+			return response.HandleErrors(HttpStatusCode.Created);
+		}
 
-        /// <summary>
-        ///     Get issue information
-        ///     See: https://docs.atlassian.com/jira/REST/latest/#d2e4539
-        /// </summary>
-        /// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
-        /// <param name="issueKey">the issue key</param>
-        /// <param name="cancellationToken">CancellationToken</param>
-        /// <returns>Issue</returns>
-        public static async Task<TIssue> GetAsync<TIssue, TFields>(this IIssueDomain jiraClient, string issueKey, CancellationToken cancellationToken = default)
-            where TIssue : IssueWithFields<TFields>
-            where TFields : IssueFields
-        {
-            if (issueKey == null)
-            {
-                throw new ArgumentNullException(nameof(issueKey));
-            }
-            Log.Debug().WriteLine("Retrieving issue information for {0}", issueKey);
-            var issueUri = jiraClient.JiraRestUri.AppendSegments("issue", issueKey);
-            // Add the configurable expand values, if the value is not null or empty
-            if (JiraConfig.ExpandGetIssue?.Length > 0)
-            {
-                issueUri = issueUri.ExtendQuery("expand", string.Join(",", JiraConfig.ExpandGetIssue));
-            }
-            jiraClient.Behaviour.MakeCurrent();
+		/// <summary>
+		///     Get issue information
+		///     See: https://docs.atlassian.com/jira/REST/latest/#d2e4539
+		/// </summary>
+		/// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
+		/// <param name="issueKey">the issue key</param>
+		/// <param name="cancellationToken">CancellationToken</param>
+		/// <returns>Issue</returns>
+		public static async Task<TIssue> GetAsync<TIssue, TFields>(this IIssueDomain jiraClient, string issueKey, CancellationToken cancellationToken = default)
+			where TIssue : IssueWithFields<TFields>
+			where TFields : IssueFields
+		{
+			if (issueKey == null)
+			{
+				throw new ArgumentNullException(nameof(issueKey));
+			}
+			Log.Debug().WriteLine("Retrieving issue information for {0}", issueKey);
+			var issueUri = jiraClient.JiraRestUri.AppendSegments("issue", issueKey);
+			// Add the configurable expand values, if the value is not null or empty
+			if (JiraConfig.ExpandGetIssue?.Length > 0)
+			{
+				issueUri = issueUri.ExtendQuery("expand", string.Join(",", JiraConfig.ExpandGetIssue));
+			}
+			jiraClient.Behaviour.MakeCurrent();
 
-            var response = await issueUri.GetAsAsync<HttpResponse<TIssue, Error>>(cancellationToken).ConfigureAwait(false);
-            return response.HandleErrors();
-        }
+			var response = await issueUri.GetAsAsync<HttpResponse<TIssue, Error>>(cancellationToken).ConfigureAwait(false);
+			return response.HandleErrors();
+		}
 
-        /// <summary>
-        ///     Get issue information
-        ///     See: https://docs.atlassian.com/jira/REST/latest/#d2e4539
-        /// </summary>
-        /// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
-        /// <param name="issueKey">the issue key</param>
-        /// <param name="cancellationToken">CancellationToken</param>
-        /// <returns>Issue</returns>
-        public static Task<Issue> GetAsync(this IIssueDomain jiraClient, string issueKey, CancellationToken cancellationToken = default)
-        {
-            return jiraClient.GetAsync<Issue, IssueFields>(issueKey, cancellationToken);
-        }
+		/// <summary>
+		///     Get issue information
+		///     See: https://docs.atlassian.com/jira/REST/latest/#d2e4539
+		/// </summary>
+		/// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
+		/// <param name="issueKey">the issue key</param>
+		/// <param name="cancellationToken">CancellationToken</param>
+		/// <returns>Issue</returns>
+		public static Task<Issue> GetAsync(this IIssueDomain jiraClient, string issueKey, CancellationToken cancellationToken = default)
+		{
+			return jiraClient.GetAsync<Issue, IssueFields>(issueKey, cancellationToken);
+		}
 
-        /// <summary>
-        ///     Get possible transitions for the specified issue
-        ///     See: https://docs.atlassian.com/jira/REST/latest/#d2e1289
-        /// </summary>
-        /// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
-        /// <param name="issueKey">the issue key</param>
-        /// <param name="cancellationToken">CancellationToken</param>
-        /// <returns>List of Transition</returns>
-        public static async Task<IList<Transition>> GetPossibleTransitionsAsync(this IIssueDomain jiraClient, string issueKey,
-            CancellationToken cancellationToken = default)
-        {
-            if (issueKey == null)
-            {
-                throw new ArgumentNullException(nameof(issueKey));
-            }
-            Log.Debug().WriteLine("Retrieving transition information for {0}", issueKey);
-            var transitionsUri = jiraClient.JiraRestUri.AppendSegments("issue", issueKey, "transitions");
-            if (JiraConfig.ExpandGetTransitions?.Length > 0)
-            {
-                transitionsUri = transitionsUri.ExtendQuery("expand", string.Join(",", JiraConfig.ExpandGetTransitions));
-            }
-            jiraClient.Behaviour.MakeCurrent();
-            var response = await transitionsUri.GetAsAsync<HttpResponse<Transitions, Error>>(cancellationToken).ConfigureAwait(false);
-            return response.HandleErrors().Items;
-        }
+		/// <summary>
+		///     Get possible transitions for the specified issue
+		///     See: https://docs.atlassian.com/jira/REST/latest/#d2e1289
+		/// </summary>
+		/// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
+		/// <param name="issueKey">the issue key</param>
+		/// <param name="cancellationToken">CancellationToken</param>
+		/// <returns>List of Transition</returns>
+		public static async Task<IList<Transition>> GetPossibleTransitionsAsync(this IIssueDomain jiraClient, string issueKey, CancellationToken cancellationToken = default)
+		{
+			if (issueKey == null)
+			{
+				throw new ArgumentNullException(nameof(issueKey));
+			}
+			Log.Debug().WriteLine("Retrieving transition information for {0}", issueKey);
+			var transitionsUri = jiraClient.JiraRestUri.AppendSegments("issue", issueKey, "transitions");
+			if (JiraConfig.ExpandGetTransitions?.Length > 0)
+			{
+				transitionsUri = transitionsUri.ExtendQuery("expand", string.Join(",", JiraConfig.ExpandGetTransitions));
+			}
+			jiraClient.Behaviour.MakeCurrent();
+			var response = await transitionsUri.GetAsAsync<HttpResponse<Transitions, Error>>(cancellationToken).ConfigureAwait(false);
+			return response.HandleErrors().Items;
+		}
 
-        /// <summary>
-        ///     Search for issues, with a JQL (e.g. from a filter)
-        ///     See: https://docs.atlassian.com/jira/REST/latest/#d2e2713
-        /// </summary>
-        /// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
-        /// <param name="jql">Jira Query Language, like SQL, for the search. Use Where builder</param>
-        /// <param name="startAt">Start of the results to return, used for paging. Default is 0</param>
-        /// <param name="maxResults">Maximum number of results returned, default is 20</param>
-        /// <param name="fields">Jira fields to include, if null the defaults from the JiraConfig.SearchFields are taken</param>
-        /// <param name="cancellationToken">CancellationToken</param>
-        /// <returns>SearchResults</returns>
-        public static Task<SearchIssuesResult<Issue, JqlIssueSearch>> SearchAsync(this IIssueDomain jiraClient, IFinalClause jql, int maxResults = 20, int startAt = 0, IEnumerable<string> fields = null,
-            CancellationToken cancellationToken = default)
-        {
-            return jiraClient.SearchAsync(jql.ToString(), new Page {MaxResults = maxResults, StartAt = startAt}, fields, cancellationToken);
-        }
+		/// <summary>
+		///     Search for issues, with a JQL (e.g. from a filter)
+		///     See: https://docs.atlassian.com/jira/REST/latest/#d2e2713
+		/// </summary>
+		/// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
+		/// <param name="jql">Jira Query Language, like SQL, for the search. Use Where builder</param>
+		/// <param name="startAt">Start of the results to return, used for paging. Default is 0</param>
+		/// <param name="maxResults">Maximum number of results returned, default is 20</param>
+		/// <param name="fields">Jira fields to include, if null the defaults from the JiraConfig.SearchFields are taken</param>
+		/// <param name="expand">
+		///     Additional fields to includes in the results, if null the defaults from the
+		///     JiraConfig.ExpandSearch are taken
+		/// </param>
+		/// <param name="cancellationToken">CancellationToken</param>
+		/// <returns>SearchResults</returns>
+		public static Task<SearchIssuesResult<Issue, JqlIssueSearch>> SearchAsync(this IIssueDomain jiraClient, IFinalClause jql, int maxResults = 20, int startAt = 0,
+			IEnumerable<string> fields = null, IEnumerable<string> expand = null, CancellationToken cancellationToken = default)
+		{
+			return jiraClient.SearchAsync(jql.ToString(), new Page {MaxResults = maxResults, StartAt = startAt}, fields, expand, cancellationToken);
+		}
 
-        /// <summary>
-        ///     Search for issues, with a JQL (e.g. from a filter)
-        ///     See: https://docs.atlassian.com/jira/REST/latest/#d2e2713
-        /// </summary>
-        /// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
-        /// <param name="jql">Jira Query Language, like SQL, for the search</param>
-        /// <param name="page">Page with paging information, default this starts at the beginning with a maxResults of 20</param>
-        /// <param name="fields">Jira fields to include, if null the defaults from the JiraConfig.SearchFields are taken</param>
-        /// <param name="cancellationToken">CancellationToken</param>
-        /// <returns>SearchIssuesResult</returns>
-        public static Task<SearchIssuesResult<Issue, JqlIssueSearch>> SearchAsync(this IIssueDomain jiraClient, string jql, Page page = null, IEnumerable<string> fields = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (jql == null)
-            {
-                throw new ArgumentNullException(nameof(jql));
-            }
+		/// <summary>
+		///     Search for issues, with a JQL (e.g. from a filter)
+		///     See: https://docs.atlassian.com/jira/REST/latest/#d2e2713
+		/// </summary>
+		/// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
+		/// <param name="jql">Jira Query Language, like SQL, for the search</param>
+		/// <param name="page">Page with paging information, default this starts at the beginning with a maxResults of 20</param>
+		/// <param name="fields">Jira fields to include, if null the defaults from the JiraConfig.SearchFields are taken</param>
+		/// <param name="expand">
+		///     Additional fields to includes in the results, if null the defaults from the
+		///     JiraConfig.ExpandSearch are taken
+		/// </param>
+		/// <param name="cancellationToken">CancellationToken</param>
+		/// <returns>
+		///     SearchIssuesResult
+		/// </returns>
+		public static Task<SearchIssuesResult<Issue, JqlIssueSearch>> SearchAsync(this IIssueDomain jiraClient, string jql, Page page = null, IEnumerable<string> fields = null,
+			IEnumerable<string> expand = null, CancellationToken cancellationToken = default)
+		{
+			if (jql == null)
+			{
+				throw new ArgumentNullException(nameof(jql));
+			}
 
-            var search = new JqlIssueSearch
-            {
-                Jql = jql,
-                ValidateQuery = true,
-                MaxResults = page?.MaxResults ?? 20,
-                StartAt = page?.StartAt ?? 0,
-                Fields = fields ?? new List<string>(JiraConfig.SearchFields)
-            };
-            return jiraClient.SearchAsync(search, cancellationToken);
-        }
+			var search = new JqlIssueSearch
+			{
+				Jql = jql,
+				ValidateQuery = true,
+				MaxResults = page?.MaxResults ?? 20,
+				StartAt = page?.StartAt ?? 0,
+				Fields = fields ?? new List<string>(JiraConfig.SearchFields),
+				Expand = expand ?? (JiraConfig.ExpandSearch != null ? new List<string>(JiraConfig.ExpandSearch) : null)
+			};
+			return jiraClient.SearchAsync(search, cancellationToken);
+		}
 
-        /// <summary>
-        ///     Search for issues, with a JQL (e.g. from a filter)
-        ///     See: https://docs.atlassian.com/jira/REST/latest/#d2e2713
-        /// </summary>
-        /// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
-        /// <param name="search">Search information, with Jira Query Language, like SQL, for the search</param>
-        /// <param name="page">Page with paging information, overwriting the page info in the search.</param>
-        /// <param name="fields">Jira fields to include, if null the defaults from the JiraConfig.SearchFields are taken</param>
-        /// <param name="cancellationToken">CancellationToken</param>
-        /// <returns>SearchIssuesResult</returns>
-        public static Task<SearchIssuesResult<Issue, JqlIssueSearch>> SearchAsync(this IIssueDomain jiraClient, JqlIssueSearch search, Page page = null, IEnumerable<string> fields = null,
-            CancellationToken cancellationToken = default)
-        {
-            if (search == null)
-            {
-                throw new ArgumentNullException(nameof(search));
-            }
+		/// <summary>
+		///     Search for issues, with a JQL (e.g. from a filter)
+		///     See: https://docs.atlassian.com/jira/REST/latest/#d2e2713
+		/// </summary>
+		/// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
+		/// <param name="search">Search information, with Jira Query Language, like SQL, for the search</param>
+		/// <param name="page">Page with paging information, overwriting the page info in the search.</param>
+		/// <param name="fields">Jira fields to include, if null the defaults from the JiraConfig.SearchFields are taken</param>
+		/// <param name="cancellationToken">CancellationToken</param>
+		/// <returns>SearchIssuesResult</returns>
+		public static Task<SearchIssuesResult<Issue, JqlIssueSearch>> SearchAsync(this IIssueDomain jiraClient, JqlIssueSearch search, Page page = null, IEnumerable<string> fields = null,
+			CancellationToken cancellationToken = default)
+		{
+			if (search == null)
+			{
+				throw new ArgumentNullException(nameof(search));
+			}
 
-            if (page != null)
-            {
-                search.MaxResults = page.MaxResults ?? 20;
-                search.StartAt = page.StartAt ?? 0;
-            }
-            return jiraClient.SearchAsync(search, cancellationToken);
-        }
+			if (page != null)
+			{
+				search.MaxResults = page.MaxResults ?? 20;
+				search.StartAt = page.StartAt ?? 0;
+			}
+			return jiraClient.SearchAsync(search, cancellationToken);
+		}
 
-        /// <summary>
-        ///     Search for issues, with a JQL (e.g. from a filter)
-        ///     See: https://docs.atlassian.com/jira/REST/latest/#d2e2713
-        /// </summary>
-        /// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
-        /// <param name="search">The search arguments</param>
-        /// <param name="cancellationToken">CancellationToken</param>
-        /// <returns>SearchIssuesResult</returns>
-        public static async Task<SearchIssuesResult<Issue, JqlIssueSearch>> SearchAsync(this IIssueDomain jiraClient, JqlIssueSearch search, CancellationToken cancellationToken = default)
-        {
-            if (search == null)
-            {
-                throw new ArgumentNullException(nameof(search));
-            }
+		/// <summary>
+		///     Search for issues, with a JQL (e.g. from a filter)
+		///     See: https://docs.atlassian.com/jira/REST/latest/#d2e2713
+		/// </summary>
+		/// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
+		/// <param name="search">The search arguments</param>
+		/// <param name="cancellationToken">CancellationToken</param>
+		/// <returns>SearchIssuesResult</returns>
+		public static async Task<SearchIssuesResult<Issue, JqlIssueSearch>> SearchAsync(this IIssueDomain jiraClient, JqlIssueSearch search, CancellationToken cancellationToken = default)
+		{
+			if (search == null)
+			{
+				throw new ArgumentNullException(nameof(search));
+			}
 
-            Log.Debug().WriteLine("Searching via JQL: {0}", search.Jql);
+			Log.Debug().WriteLine("Searching via JQL: {0}", search.Jql);
 
-            jiraClient.Behaviour.MakeCurrent();
-            var searchUri = jiraClient.JiraRestUri.AppendSegments("search");
+			jiraClient.Behaviour.MakeCurrent();
+			var searchUri = jiraClient.JiraRestUri.AppendSegments("search");
 
-            // Add the configurable expand values, if the value is not null or empty
-            if (JiraConfig.ExpandSearch?.Length > 0)
-            {
-                searchUri = searchUri.ExtendQuery("expand", string.Join(",", JiraConfig.ExpandSearch));
-            }
+			var response = await searchUri
+				.PostAsync<HttpResponse<SearchIssuesResult<Issue, JqlIssueSearch>, Error>>(search, cancellationToken)
+				.ConfigureAwait(false);
+			var result = response.HandleErrors();
+			// Store the original search parameter
+			result.SearchParameter = search;
+			return result;
+		}
 
-            var response = await searchUri.PostAsync<HttpResponse<SearchIssuesResult<Issue, JqlIssueSearch>, Error>>(search, cancellationToken).ConfigureAwait(false);
-            var result = response.HandleErrors();
-            // Store the original search parameter
-            result.SearchParameter = search;
-            return result;
-        }
+		/// <summary>
+		///     Update comment
+		///     See: https://docs.atlassian.com/jira/REST/latest/#d2e1139
+		/// </summary>
+		/// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
+		/// <param name="issueKey">jira key to which the comment belongs</param>
+		/// <param name="comment">Comment to update</param>
+		/// <param name="cancellationToken">CancellationToken</param>
+		/// <returns>Comment</returns>
+		public static async Task<Comment> UpdateCommentAsync(this IIssueDomain jiraClient, string issueKey, Comment comment, CancellationToken cancellationToken = default)
+		{
+			if (issueKey == null)
+			{
+				throw new ArgumentNullException(nameof(issueKey));
+			}
 
-        /// <summary>
-        ///     Update comment
-        ///     See: https://docs.atlassian.com/jira/REST/latest/#d2e1139
-        /// </summary>
-        /// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
-        /// <param name="issueKey">jira key to which the comment belongs</param>
-        /// <param name="comment">Comment to update</param>
-        /// <param name="cancellationToken">CancellationToken</param>
-        /// <returns>Comment</returns>
-        public static async Task<Comment> UpdateCommentAsync(this IIssueDomain jiraClient, string issueKey, Comment comment, CancellationToken cancellationToken = default)
-        {
-            if (issueKey == null)
-            {
-                throw new ArgumentNullException(nameof(issueKey));
-            }
+			Log.Debug().WriteLine("Updating comment {0} for issue {1}", comment.Id, issueKey);
 
-            Log.Debug().WriteLine("Updating comment {0} for issue {1}", comment.Id, issueKey);
+			jiraClient.Behaviour.MakeCurrent();
 
-            jiraClient.Behaviour.MakeCurrent();
+			var attachUri = jiraClient.JiraRestUri.AppendSegments("issue", issueKey, "comment", comment.Id);
+			var response = await attachUri.PutAsync<HttpResponse<Comment, Error>>(comment, cancellationToken).ConfigureAwait(false);
+			return response.HandleErrors();
+		}
 
-            var attachUri = jiraClient.JiraRestUri.AppendSegments("issue", issueKey, "comment", comment.Id);
-            var response = await attachUri.PutAsync<HttpResponse<Comment, Error>>(comment, cancellationToken).ConfigureAwait(false);
-            return response.HandleErrors();
-        }
+		/// <summary>
+		///     Get a list of all possible issue types
+		/// </summary>
+		/// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
+		/// <param name="cancellationToken">CancellationToken</param>
+		/// <returns>List with IssueType elements</returns>
+		public static async Task<IList<IssueType>> GetIssueTypesAsync(this IIssueDomain jiraClient, CancellationToken cancellationToken = new CancellationToken())
+		{
+			var issueTypesUri = jiraClient.JiraRestUri.AppendSegments("issuetype");
+			jiraClient.Behaviour.MakeCurrent();
+			var response = await issueTypesUri.GetAsAsync<HttpResponse<IList<IssueType>, Error>>(cancellationToken).ConfigureAwait(false);
+			return response.HandleErrors();
+		}
 
-        /// <summary>
-        ///     Get a list of all possible issue types
-        /// </summary>
-        /// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
-        /// <param name="cancellationToken">CancellationToken</param>
-        /// <returns>List with IssueType elements</returns>
-        public static async Task<IList<IssueType>> GetIssueTypesAsync(this IIssueDomain jiraClient, CancellationToken cancellationToken = new CancellationToken())
-        {
-            var issueTypesUri = jiraClient.JiraRestUri.AppendSegments("issuetype");
-            jiraClient.Behaviour.MakeCurrent();
-            var response = await issueTypesUri.GetAsAsync<HttpResponse<IList<IssueType>, Error>>(cancellationToken).ConfigureAwait(false);
-            return response.HandleErrors();
-        }
+		/// <summary>
+		///     Create an issue
+		/// </summary>
+		/// <typeparam name="TFields">The type of the issue fields</typeparam>
+		/// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
+		/// <param name="issue">the issue to create</param>
+		/// <param name="cancellationToken">CancellationToken</param>
+		/// <returns>Issue</returns>
+		public static async Task<IssueWithFields<TFields>> CreateAsync<TFields>(this IIssueDomain jiraClient, IssueWithFields<TFields> issue, CancellationToken cancellationToken = default)
+			where TFields : IssueFields
+		{
+			if (issue == null)
+			{
+				throw new ArgumentNullException(nameof(issue));
+			}
+			Log.Debug().WriteLine("Creating issue {0}", issue);
+			jiraClient.Behaviour.MakeCurrent();
+			var issueUri = jiraClient.JiraRestUri.AppendSegments("issue");
+			var response = await issueUri.PostAsync<HttpResponse<IssueWithFields<TFields>, Error>>(issue, cancellationToken).ConfigureAwait(false);
+			return response.HandleErrors(HttpStatusCode.Created);
+		}
 
-        /// <summary>
-        ///     Create an issue
-        /// </summary>
-        /// <typeparam name="TFields">The type of the issue fields</typeparam>
-        /// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
-        /// <param name="issue">the issue to create</param>
-        /// <param name="cancellationToken">CancellationToken</param>
-        /// <returns>Issue</returns>
-        public static async Task<IssueWithFields<TFields>> CreateAsync<TFields>(this IIssueDomain jiraClient, IssueWithFields<TFields> issue, CancellationToken cancellationToken = default)
-            where TFields : IssueFields
-        {
-            if (issue == null)
-            {
-                throw new ArgumentNullException(nameof(issue));
-            }
-            Log.Debug().WriteLine("Creating issue {0}", issue);
-            jiraClient.Behaviour.MakeCurrent();
-            var issueUri = jiraClient.JiraRestUri.AppendSegments("issue");
-            var response = await issueUri.PostAsync<HttpResponse<IssueWithFields<TFields>, Error>>(issue, cancellationToken).ConfigureAwait(false);
-            return response.HandleErrors(HttpStatusCode.Created);
-        }
+		/// <summary>
+		///     Update an issue
+		/// </summary>
+		/// <typeparam name="TFields">The type of the issue</typeparam>
+		/// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
+		/// <param name="issue">the issue to update</param>
+		/// <param name="notifyUsers">
+		///     send the email with notification that the issue was updated to users that watch it. Admin or
+		///     project admin permissions are required to disable the notification. default = true
+		/// </param>
+		/// <param name="overrideScreenSecurity">
+		///     allows to update fields that are not on the screen. Only connect add-on users with
+		///     admin scope permission are allowed to use this flag. default = false
+		/// </param>
+		/// <param name="overrideEditableFlag">
+		///     Updates the issue even if the issue is not editable due to being in a status with
+		///     jira.issue.editable set to false or missing. Only connect add-on users with admin scope permission are allowed to
+		///     use this flag. default = false
+		/// </param>
+		/// <param name="cancellationToken">CancellationToken</param>
+		/// <returns>TIssue</returns>
+		public static async Task UpdateAsync<TFields>(this IIssueDomain jiraClient, IssueWithFields<TFields> issue, bool notifyUsers = true, bool overrideScreenSecurity = false, bool overrideEditableFlag = false, CancellationToken cancellationToken = default)
+			where TFields : IssueFields
+		{
+			if (issue == null)
+			{
+				throw new ArgumentNullException(nameof(issue));
+			}
+			Log.Debug().WriteLine("Updating issue {0}", issue.Key);
+			jiraClient.Behaviour.MakeCurrent();
+			var issueToUpdate = new IssueWithFields<TFields>
+			{
+				Fields = issue.Fields
+			};
+			var issueUri = jiraClient.JiraRestUri.AppendSegments("issue", issue.Key).ExtendQuery(new Dictionary<string, bool>
+			{
+				{"notifyUsers", notifyUsers},
+				{"overrideScreenSecurity", overrideScreenSecurity},
+				{"overrideEditableFlag", overrideEditableFlag}
+			});
+			var response = await issueUri.PutAsync<HttpResponseWithError<Error>>(issueToUpdate, cancellationToken).ConfigureAwait(false);
+			// Expect HttpStatusCode.NoContent throw error if not
+			response.HandleStatusCode(HttpStatusCode.NoContent);
+		}
 
-        /// <summary>
-        ///     Update an issue
-        /// </summary>
-        /// <typeparam name="TFields">The type of the issue</typeparam>
-        /// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
-        /// <param name="issue">the issue to update</param>
-        /// <param name="notifyUsers">send the email with notification that the issue was updated to users that watch it. Admin or project admin permissions are required to disable the notification. default = true</param>
-        /// <param name="overrideScreenSecurity">allows to update fields that are not on the screen. Only connect add-on users with admin scope permission are allowed to use this flag. default = false</param>
-        /// <param name="overrideEditableFlag">Updates the issue even if the issue is not editable due to being in a status with jira.issue.editable set to false or missing. Only connect add-on users with admin scope permission are allowed to use this flag. default = false</param>
-        /// <param name="cancellationToken">CancellationToken</param>
-        /// <returns>TIssue</returns>
-        public static async Task UpdateAsync<TFields>(this IIssueDomain jiraClient, IssueWithFields<TFields> issue, bool notifyUsers = true, bool overrideScreenSecurity = false,  bool overrideEditableFlag= false, CancellationToken cancellationToken = default)
-            where TFields : IssueFields
-        {
-            if (issue == null)
-            {
-                throw new ArgumentNullException(nameof(issue));
-            }
-            Log.Debug().WriteLine("Updating issue {0}", issue.Key);
-            jiraClient.Behaviour.MakeCurrent();
-            var issueToUpdate = new IssueWithFields<TFields>
-            {
-                Fields = issue.Fields
-            };
-            var issueUri = jiraClient.JiraRestUri.AppendSegments("issue", issue.Key).ExtendQuery(new Dictionary<string, bool>
-            {
-                { "notifyUsers", notifyUsers},
-                { "overrideScreenSecurity", overrideScreenSecurity},
-                { "overrideEditableFlag", overrideEditableFlag}
-            });
-            var response = await issueUri.PutAsync<HttpResponseWithError<Error>>(issueToUpdate, cancellationToken).ConfigureAwait(false);
-            // Expect HttpStatusCode.NoContent throw error if not
-            response.HandleStatusCode(HttpStatusCode.NoContent);
-        }
+		/// <summary>
+		///     Delete an issue
+		/// </summary>
+		/// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
+		/// <param name="issueKey">the key of the issue to delete</param>
+		/// <param name="deleteSubtasks">
+		///     true or false (default) indicating that any subtasks should also be deleted.
+		///     If the issue has no subtasks this parameter is ignored. If the issue has subtasks and this parameter is missing or
+		///     false, then the issue will not be deleted and an error will be returned
+		/// </param>
+		/// <param name="cancellationToken">CancellationToken</param>
+		public static async Task DeleteAsync(this IIssueDomain jiraClient, string issueKey, bool deleteSubtasks = false,
+			CancellationToken cancellationToken = default)
+		{
+			if (issueKey == null)
+			{
+				throw new ArgumentNullException(nameof(issueKey));
+			}
+			jiraClient.Behaviour.MakeCurrent();
+			var issueUri = jiraClient.JiraRestUri.AppendSegments("issue", issueKey);
+			if (deleteSubtasks)
+			{
+				issueUri = issueUri.ExtendQuery("deleteSubtasks", true);
+			}
+			var response = await issueUri.DeleteAsync<HttpResponse>(cancellationToken).ConfigureAwait(false);
+			response.HandleStatusCode(HttpStatusCode.NoContent);
+		}
 
-        /// <summary>
-        ///     Delete an issue
-        /// </summary>
-        /// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
-        /// <param name="issueKey">the key of the issue to delete</param>
-        /// <param name="deleteSubtasks">
-        ///     true or false (default) indicating that any subtasks should also be deleted.
-        ///     If the issue has no subtasks this parameter is ignored. If the issue has subtasks and this parameter is missing or
-        ///     false, then the issue will not be deleted and an error will be returned
-        /// </param>
-        /// <param name="cancellationToken">CancellationToken</param>
-        public static async Task DeleteAsync(this IIssueDomain jiraClient, string issueKey, bool deleteSubtasks = false,
-            CancellationToken cancellationToken = default)
-        {
-            if (issueKey == null)
-            {
-                throw new ArgumentNullException(nameof(issueKey));
-            }
-            jiraClient.Behaviour.MakeCurrent();
-            var issueUri = jiraClient.JiraRestUri.AppendSegments("issue", issueKey);
-            if (deleteSubtasks)
-            {
-                issueUri = issueUri.ExtendQuery("deleteSubtasks", true);
-            }
-            var response = await issueUri.DeleteAsync<HttpResponse>(cancellationToken).ConfigureAwait(false);
-            response.HandleStatusCode(HttpStatusCode.NoContent);
-        }
+		/// <summary>
+		///     Assign an issue to a user
+		/// </summary>
+		/// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
+		/// <param name="issueKey">Key for the issue to assign</param>
+		/// <param name="user">User to assign to, use User.Nobody to remove the assignee or User.Default to automaticly assign</param>
+		/// <param name="cancellationToken">CancellationToken</param>
+		public static async Task AssignAsync(this IIssueDomain jiraClient, string issueKey, User user, CancellationToken cancellationToken = default)
+		{
+			if (user == null)
+			{
+				user = User.Nobody;
+			}
 
-        /// <summary>
-        ///     Assign an issue to a user
-        /// </summary>
-        /// <param name="jiraClient">IIssueDomain to bind the extension method to</param>
-        /// <param name="issueKey">Key for the issue to assign</param>
-        /// <param name="user">User to assign to, use User.Nobody to remove the assignee or User.Default to automaticly assign</param>
-        /// <param name="cancellationToken">CancellationToken</param>
-        public static async Task AssignAsync(this IIssueDomain jiraClient, string issueKey, User user, CancellationToken cancellationToken = default)
-        {
-            if (user == null)
-            {
-                user = User.Nobody;
-            }
+			jiraClient.Behaviour.MakeCurrent();
+			var issueUri = jiraClient.JiraRestUri.AppendSegments("issue", issueKey, "assignee");
+			var response = await issueUri.PutAsync<HttpResponse>(user, cancellationToken).ConfigureAwait(false);
+			response.HandleStatusCode(HttpStatusCode.NoContent, HttpStatusCode.OK);
+		}
 
-            jiraClient.Behaviour.MakeCurrent();
-            var issueUri = jiraClient.JiraRestUri.AppendSegments("issue", issueKey, "assignee");
-            var response = await issueUri.PutAsync<HttpResponse>(user, cancellationToken).ConfigureAwait(false);
-            response.HandleStatusCode(HttpStatusCode.NoContent, HttpStatusCode.OK);
-        }
-
-        /// <summary>
-        /// Retrieve the users who this issue can be assigned to
-        /// </summary>
-        /// <param name="jiraClient">IProjectDomain</param>
-        /// <param name="issueKey">string with the key of the issue</param>
-        /// <param name="userpattern">optional string with a pattern to match the user to</param>
-        /// <param name="startAt">optional int with the start, used for paging</param>
-        /// <param name="maxResults">optional int with the maximum number of results, default is 50</param>
-        /// <param name="cancellationToken">CancellationToken</param>
-        /// <returns>IEnumerable with User</returns>
-        public static Task<IEnumerable<User>> GetAssignableUsersAsync(this IIssueDomain jiraClient, string issueKey, string userpattern = null, int? startAt = null, int? maxResults = null, CancellationToken cancellationToken = default)
-        {
-            return jiraClient.User.GetAssignableUsersAsync(issueKey: issueKey, username: userpattern, startAt: startAt, maxResults: maxResults, cancellationToken: cancellationToken);
-        }
-    }
+		/// <summary>
+		///     Retrieve the users who this issue can be assigned to
+		/// </summary>
+		/// <param name="jiraClient">IProjectDomain</param>
+		/// <param name="issueKey">string with the key of the issue</param>
+		/// <param name="userpattern">optional string with a pattern to match the user to</param>
+		/// <param name="startAt">optional int with the start, used for paging</param>
+		/// <param name="maxResults">optional int with the maximum number of results, default is 50</param>
+		/// <param name="cancellationToken">CancellationToken</param>
+		/// <returns>IEnumerable with User</returns>
+		public static Task<IEnumerable<User>> GetAssignableUsersAsync(this IIssueDomain jiraClient, string issueKey, string userpattern = null, int? startAt = null, int? maxResults = null, CancellationToken cancellationToken = default)
+		{
+			return jiraClient.User.GetAssignableUsersAsync(issueKey: issueKey, username: userpattern, startAt: startAt, maxResults: maxResults, cancellationToken: cancellationToken);
+		}
+	}
 }


### PR DESCRIPTION
This is the implementation I needed for #27 .
It allow the users to use the "Expand" to get the changelogs. I think I respected the format you're using.

 - Adding the models
 - modifying the issues to contains the integration
 - Storing the expand information as a list(like fields) in the IssueSearch
 - Removing the Expand from the AsyncSearch URL, since it's a POST request, the information is contained in the body and should not appears in the URL