### PR TITLE
Add ProjectTypeKey property on Project entity

### DIFF
--- a/src/Dapplo.Jira/Entities/Project.cs
+++ b/src/Dapplo.Jira/Entities/Project.cs
@@ -80,5 +80,11 @@ namespace Dapplo.Jira.Entities
 		/// </summary>
 		[JsonProperty("versions")]
 		public IList<Version> Versions { get; set; }
+
+		 /// <summary>
+        ///     The project type e.g. software, service_desk, business
+        /// </summary>
+        [JsonProperty("projectTypeKey")]
+        public string ProjectTypeKey { get; set; }
 	}
 }


### PR DESCRIPTION
The project entity is missing ProjectTypeKey. It should be present both when getting a project throught the project API and when getting an issue and viewing the attached project.

![image](https://user-images.githubusercontent.com/10304156/72157785-09868a80-33b9-11ea-911e-14378a93bf3c.png)
