### PR TITLE
Added support for updating an issue with link to another issue + 2 tests

### DIFF
--- a/src/Dapplo.Jira/Entities/IssueLink.cs
+++ b/src/Dapplo.Jira/Entities/IssueLink.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Dapplo.Jira.Entities
+{
+    /// <summary>
+    ///     Describes a link between jira issues  
+    /// </summary>
+    [JsonObject]
+    public class IssueLink
+    {
+        /// <summary>
+        /// Used to add link
+        /// </summary>
+        [JsonProperty("add")]
+        public IssueLinkAdd Add { get; set; }
+
+    }
+
+    [JsonObject]
+    public class IssueLinkAdd
+    {
+        /// <summary>
+        /// Describes type of link
+        /// </summary>
+        [JsonProperty("type")]
+        public IssuelinkType Type { get; set; }
+
+        /// <summary>
+        /// The outward issue to link to
+        /// </summary>
+        [JsonProperty("outwardIssue")]
+        public OutwardIssue OutwardIssue { get; set; }
+    }
+
+    [JsonObject]
+    public class OutwardIssue
+    {
+        /// <summary>
+        /// Issue key of linked issue
+        /// </summary>
+        [JsonProperty("key")]
+        public string Key { get; set; }
+        
+    }
+
+    [JsonObject]
+    public class IssuelinkType
+    {
+        /// <summary>
+        /// Name of issue link type
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Inward relation link name
+        /// </summary>
+        [JsonProperty("inward")]
+        public string Inward { get; set; }
+
+        /// <summary>
+        /// Outward relation link name
+        /// </summary>
+        [JsonProperty("outward")]
+        public string Outward { get; set; }
+
+    }
+}

--- a/src/Dapplo.Jira/Entities/IssueWithFields.cs
+++ b/src/Dapplo.Jira/Entities/IssueWithFields.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Dapplo and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Dapplo.Jira.Entities
@@ -24,5 +25,12 @@ namespace Dapplo.Jira.Entities
 		/// </summary>
 		[JsonProperty("renderedFields")]
 		public TFields RenderedFields { get; set; }
+
+		/// <summary>
+		/// 	Used eg. for issue linking
+		/// </summary>
+		[JsonProperty("update")]
+		public Update Update { get; set; }
+
 	}
 }

--- a/src/Dapplo.Jira/Entities/Update.cs
+++ b/src/Dapplo.Jira/Entities/Update.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Dapplo.Jira.Entities
+{
+    /// <summary>
+    ///     Container for certain update fields
+    /// </summary>
+    [JsonObject]
+    public class Update
+    {
+        /// <summary>
+        ///     Container for issue links
+        /// </summary>
+        [JsonProperty("issuelinks")]
+        public List<IssueLink> IssueLinks { get; set; }
+    }
+}

--- a/src/Dapplo.Jira/IssueExtensions.cs
+++ b/src/Dapplo.Jira/IssueExtensions.cs
@@ -329,7 +329,8 @@ namespace Dapplo.Jira
 			jiraClient.Behaviour.MakeCurrent();
 			var issueToUpdate = new IssueWithFields<TFields>
 			{
-				Fields = issue.Fields
+				Fields = issue.Fields,
+				Update = issue.Update
 			};
 			var issueUri = jiraClient.JiraRestUri.AppendSegments("issue", issue.Key).ExtendQuery(new Dictionary<string, bool>
 			{


### PR DESCRIPTION
Added support for updating an issue with link to another issue + two test (UpdateIssueLinks and CreateIssueWithCustomFields).

I have reused IssueExtensions.UpdateAsync to support both "Fields" and "Update" (which is the type that is required for linking issues). The implementation is rather simple, perhaps you want to review the code and suggest some changes. 

BTW I was unable to run most of your tests as they result in a 404 from https://greenshot.atlassian.net and I have not looked into why.